### PR TITLE
feat: update contract from changes to SIP

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,29 +6,23 @@ https://github.com/stacksgov/sips/pull/5
 
 This token standard implements the "Standard Trait Definition for Non-Fungible Tokens."  This trait exposes functions for token metadata:
 
-* name
-* symbol
-* decimals
+* get-name
+* get-symbol
+* get-decimals
+* get-token-uri
+
+The `get-token-uri` method mimics the functionality found on the ERC721 standard.  The expectation is that a token owner can set this to reference an external URI that contains extra metadata about the token (such as logos, agreements, or other documentation)
 
 In addition to metadata, it exposes functions for querying the current total supply of the token and the balance for a specific account:
 
-* balance-of
-* total-supply
+* get-balance-of
+* get-total-supply
 
 Finally, it defines the function for transferring tokens:
 
 * transfer
 
 This trait is defined in `ft-trait.clar`.
-
-# Token URI
-In addition to the standard metadata provided, an additional parameter has been added:
-
-* token-uri
-
-This parameter mimics the functionality found on the ERC721 standard.  The expectation is that a token owner can set this to reference an external URI that contains extra metadata about the token (such as logos, agreements, or other documentation)
-
-This trait is defined in `metadata-uri-token-trait.clar`.
 
 # Token Restrictions
 

--- a/contracts/ft-trait.clar
+++ b/contracts/ft-trait.clar
@@ -4,18 +4,23 @@
     (transfer (uint principal principal) (response bool uint))
 
     ;; the human readable name of the token
-    (name () (response (string-ascii 32) uint))
+    (get-name () (response (string-ascii 32) uint))
 
     ;; the ticker symbol, or empty if none
-    (symbol () (response (string-ascii 32) uint))
+    (get-symbol () (response (string-ascii 32) uint))
 
     ;; the number of decimals used, e.g. 6 would mean 1_000_000 represents 1 token
-    (decimals () (response uint uint))
+    (get-decimals () (response uint uint))
 
     ;; the balance of the passed principal
-    (balance-of (principal) (response uint uint))
+    (get-balance-of (principal) (response uint uint))
 
     ;; the current total supply (which does not need to be a constant)
-    (total-supply () (response uint uint))
+    (get-total-supply () (response uint uint))
+
+    ;; Gets a URI string that will point to additional metadata about
+    ;; the token.
+    ;; This can be used for metadata, extra detailed information, investor docs, etc
+    (get-token-uri () (response (optional (string-utf8 256)) uint))
   )
 )

--- a/contracts/metadata-uri-token-trait.clar
+++ b/contracts/metadata-uri-token-trait.clar
@@ -1,8 +1,0 @@
-(define-trait metadata-uri-token-trait
-  (
-    ;; Gets a URI string that will point to additional metadata about
-    ;; the token.
-    ;; This can be used for metadata, extra detailed information, investor docs, etc
-    (token-uri () (response (string-utf8 1024) uint))
-  )
-)

--- a/contracts/tokensoft-token.clar
+++ b/contracts/tokensoft-token.clar
@@ -2,9 +2,6 @@
 ;; This can use sugared syntax in real deployment (unit tests do not allow)
 (impl-trait 'ST3J2GVMMM2R07ZFBJDWTYEYAR8FZH5WKDTFJ9AHA.ft-trait.ft-trait)
 
-;; ;; Implement the metadata URI trait
-(impl-trait 'ST3J2GVMMM2R07ZFBJDWTYEYAR8FZH5WKDTFJ9AHA.metadata-uri-token-trait.metadata-uri-token-trait)
-
 ;; ;; Implement the token restriction trait
 (impl-trait 'ST3J2GVMMM2R07ZFBJDWTYEYAR8FZH5WKDTFJ9AHA.restricted-token-trait.restricted-token-trait)
 
@@ -27,23 +24,23 @@
 (define-fungible-token tokensoft-token)
 
 ;; Get the token balance of the specified owner in base units
-(define-read-only (balance-of (owner principal))
+(define-read-only (get-balance-of (owner principal))
   (ok (ft-get-balance tokensoft-token owner)))
 
 ;; Returns the token name
-(define-read-only (name)
+(define-read-only (get-name)
   (ok (var-get token-name)))
 
 ;; Returns the symbol or "ticker" for this token
-(define-read-only (symbol)
+(define-read-only (get-symbol)
   (ok (var-get token-symbol)))
 
 ;; Returns the number of decimals used
-(define-read-only (decimals)
+(define-read-only (get-decimals)
   (ok (var-get token-decimals)))
 
 ;; Returns the total number of tokens that currently exist
-(define-read-only (total-supply)
+(define-read-only (get-total-supply)
   (ok (ft-get-supply tokensoft-token)))
 
 
@@ -107,14 +104,14 @@
 ;; --------------------------------------------------------------------------
 
 ;; Variable for URI storage
-(define-data-var uri (string-utf8 1024) u"")
+(define-data-var uri (string-utf8 256) u"")
 
 ;; Public getter for the URI
-(define-read-only (token-uri)
-  (ok (var-get uri)))
+(define-read-only (get-token-uri)
+  (ok (some (var-get uri))))
 
 ;; Setter for the URI - only the owner can set it
-(define-public (set-token-uri (updated-uri (string-utf8 1024)))
+(define-public (set-token-uri (updated-uri (string-utf8 256)))
   (if (has-role OWNER_ROLE contract-caller)
     (ok (var-set uri updated-uri))
     (err PERMISSION_DENIED_ERROR)))

--- a/src/TokenHelper/meta.ts
+++ b/src/TokenHelper/meta.ts
@@ -8,7 +8,7 @@ const name = async (client: Client) => {
 
   const query = client.createQuery({
     method: {
-      name: 'name',
+      name: 'get-name',
       args: [],
     }
   })
@@ -22,7 +22,7 @@ const name = async (client: Client) => {
  * @param client 
  */
 const symbol = async (client: Client) => {
-  const query = client.createQuery({ method: { name: "symbol", args: [] } })
+  const query = client.createQuery({ method: { name: "get-symbol", args: [] } })
   const receipt = await client.submitQuery(query)
   return Result.unwrapString(receipt, "utf8")
 }
@@ -32,7 +32,7 @@ const symbol = async (client: Client) => {
  * @param client 
  */
 const decimals = async (client: Client) => {
-  const query = client.createQuery({ method: { name: "decimals", args: [] } })
+  const query = client.createQuery({ method: { name: "get-decimals", args: [] } })
   const receipt = await client.submitQuery(query)
   return Result.unwrapUInt(receipt)
 }
@@ -42,7 +42,7 @@ const decimals = async (client: Client) => {
  * @param client 
  */
 const supply = async (client: Client) => {
-  const query = client.createQuery({ method: { name: "total-supply", args: [] } })
+  const query = client.createQuery({ method: { name: "get-total-supply", args: [] } })
   const receipt = await client.submitQuery(query)
   return Result.unwrapUInt(receipt)
 }
@@ -54,13 +54,13 @@ const supply = async (client: Client) => {
  * @returns - amount in base units
  */
 const balanceOf = async (client: Client, principal: string) => {
-  const query = client.createQuery({ method: { name: "balance-of", args: [`'${principal}`] } })
+  const query = client.createQuery({ method: { name: "get-balance-of", args: [`'${principal}`] } })
   const receipt = await client.submitQuery(query)
   return Result.unwrapUInt(receipt)
 }
 
 const tokenUri = async (client: Client) => {
-  const query = client.createQuery({ method: { name: "token-uri", args: [] } })
+  const query = client.createQuery({ method: { name: "get-token-uri", args: [] } })
   const receipt = await client.submitQuery(query)
   return receipt.result
 }

--- a/test/capabilities/blacklisting.ts
+++ b/test/capabilities/blacklisting.ts
@@ -12,7 +12,6 @@ describe("Tokensoft Token burning capability", () => {
     provider = await ProviderRegistry.createProvider()
     await createCheckAndDeploy(`${Accounts.alice}.ft-trait`, 'ft-trait', provider)
     await createCheckAndDeploy(`${Accounts.alice}.restricted-token-trait`, 'restricted-token-trait', provider)
-    await createCheckAndDeploy(`${Accounts.alice}.metadata-uri-token-trait`, 'metadata-uri-token-trait', provider)
     tokensoftTokenClient = await createCheckAndDeploy(`${Accounts.alice}.tokensoft-token`, "tokensoft-token", provider)
     await TokenHelper.Meta.initialize(
       tokensoftTokenClient,

--- a/test/capabilities/burning.ts
+++ b/test/capabilities/burning.ts
@@ -12,7 +12,6 @@ describe("Tokensoft Token burning capability", () => {
     provider = await ProviderRegistry.createProvider()
     await createCheckAndDeploy(`${Accounts.alice}.ft-trait`, 'ft-trait', provider)
     await createCheckAndDeploy(`${Accounts.alice}.restricted-token-trait`, 'restricted-token-trait', provider)
-    await createCheckAndDeploy(`${Accounts.alice}.metadata-uri-token-trait`, 'metadata-uri-token-trait', provider)
     tokensoftTokenClient = await createCheckAndDeploy(`${Accounts.alice}.tokensoft-token`, "tokensoft-token", provider)
     await TokenHelper.Meta.initialize(
       tokensoftTokenClient,

--- a/test/capabilities/minting.ts
+++ b/test/capabilities/minting.ts
@@ -12,7 +12,6 @@ describe("Tokensoft Token minting capability", () => {
     provider = await ProviderRegistry.createProvider()
     await createCheckAndDeploy(`${Accounts.alice}.ft-trait`, 'ft-trait', provider)
     await createCheckAndDeploy(`${Accounts.alice}.restricted-token-trait`, 'restricted-token-trait', provider)
-    await createCheckAndDeploy(`${Accounts.alice}.metadata-uri-token-trait`, 'metadata-uri-token-trait', provider)
     tokensoftTokenClient = await createCheckAndDeploy(`${Accounts.alice}.tokensoft-token`, "tokensoft-token", provider)
     await TokenHelper.Meta.initialize(
       tokensoftTokenClient,

--- a/test/capabilities/revoking.ts
+++ b/test/capabilities/revoking.ts
@@ -12,7 +12,6 @@ describe("Tokensoft Token revoking capability", () => {
     provider = await ProviderRegistry.createProvider()
     await createCheckAndDeploy(`${Accounts.alice}.ft-trait`, 'ft-trait', provider)
     await createCheckAndDeploy(`${Accounts.alice}.restricted-token-trait`, 'restricted-token-trait', provider)
-    await createCheckAndDeploy(`${Accounts.alice}.metadata-uri-token-trait`, 'metadata-uri-token-trait', provider)
     tokensoftTokenClient = await createCheckAndDeploy(`${Accounts.alice}.tokensoft-token`, "tokensoft-token", provider)
     await TokenHelper.Meta.initialize(
       tokensoftTokenClient,

--- a/test/capabilities/uri.ts
+++ b/test/capabilities/uri.ts
@@ -12,7 +12,6 @@ describe("Tokensoft Token URI capability", () => {
     provider = await ProviderRegistry.createProvider()
     await createCheckAndDeploy(`${Accounts.alice}.ft-trait`, 'ft-trait', provider)
     await createCheckAndDeploy(`${Accounts.alice}.restricted-token-trait`, 'restricted-token-trait', provider)
-    await createCheckAndDeploy(`${Accounts.alice}.metadata-uri-token-trait`, 'metadata-uri-token-trait', provider)
     tokensoftTokenClient = await createCheckAndDeploy(`${Accounts.alice}.tokensoft-token`, "tokensoft-token", provider)
     await TokenHelper.Meta.initialize(
       tokensoftTokenClient,
@@ -25,7 +24,7 @@ describe("Tokensoft Token URI capability", () => {
   })
 
   it("should allow bob to update the uri one he has been granted the role", async () => {
-    assert.equal((await TokenHelper.Meta.tokenUri(tokensoftTokenClient)), "(ok u\"\")")
+    assert.equal((await TokenHelper.Meta.tokenUri(tokensoftTokenClient)), "(ok (some u\"\"))")
     
     try {
       await TokenHelper.Meta.setTokenUri(
@@ -51,7 +50,7 @@ describe("Tokensoft Token URI capability", () => {
     )
 
     // Verify
-    assert.equal((await TokenHelper.Meta.tokenUri(tokensoftTokenClient)), "(ok u\"TOKENSOFT_TOKEN\")")
+    assert.equal((await TokenHelper.Meta.tokenUri(tokensoftTokenClient)), "(ok (some u\"TOKENSOFT_TOKEN\"))")
 
     // Update it again with Alice
     await TokenHelper.Meta.setTokenUri(
@@ -60,7 +59,7 @@ describe("Tokensoft Token URI capability", () => {
       Accounts.alice
     )
 
-    assert.equal((await TokenHelper.Meta.tokenUri(tokensoftTokenClient)), "(ok u\"POOLE_PARTY_TOKEN\")")
+    assert.equal((await TokenHelper.Meta.tokenUri(tokensoftTokenClient)), "(ok (some u\"POOLE_PARTY_TOKEN\"))")
 
     // Update it again with Alice
     await TokenHelper.Meta.setTokenUri(
@@ -69,7 +68,7 @@ describe("Tokensoft Token URI capability", () => {
       Accounts.alice
     )
 
-    assert.equal((await TokenHelper.Meta.tokenUri(tokensoftTokenClient)), "(ok u\"https://www.tokensoft.io/test?param=asdfasdf&param2=1235\")")
+    assert.equal((await TokenHelper.Meta.tokenUri(tokensoftTokenClient)), "(ok (some u\"https://www.tokensoft.io/test?param=asdfasdf&param2=1235\"))")
   })
 
 

--- a/test/roles/blacklister.ts
+++ b/test/roles/blacklister.ts
@@ -12,7 +12,6 @@ describe("Tokensoft Token Blacklister role permissions", () => {
     provider = await ProviderRegistry.createProvider()
     await createCheckAndDeploy(`${Accounts.alice}.ft-trait`, 'ft-trait', provider)
     await createCheckAndDeploy(`${Accounts.alice}.restricted-token-trait`, 'restricted-token-trait', provider)
-    await createCheckAndDeploy(`${Accounts.alice}.metadata-uri-token-trait`, 'metadata-uri-token-trait', provider)
     tokensoftTokenClient = await createCheckAndDeploy(`${Accounts.alice}.tokensoft-token`, "tokensoft-token", provider)
     await TokenHelper.Meta.initialize(
       tokensoftTokenClient,

--- a/test/roles/burner.ts
+++ b/test/roles/burner.ts
@@ -12,7 +12,6 @@ describe("Tokensoft Token Burner role permissions", () => {
     provider = await ProviderRegistry.createProvider()
     await createCheckAndDeploy(`${Accounts.alice}.ft-trait`, 'ft-trait', provider)
     await createCheckAndDeploy(`${Accounts.alice}.restricted-token-trait`, 'restricted-token-trait', provider)
-    await createCheckAndDeploy(`${Accounts.alice}.metadata-uri-token-trait`, 'metadata-uri-token-trait', provider)
     tokensoftTokenClient = await createCheckAndDeploy(`${Accounts.alice}.tokensoft-token`, "tokensoft-token", provider)
     await TokenHelper.Meta.initialize(
       tokensoftTokenClient,

--- a/test/roles/minter.ts
+++ b/test/roles/minter.ts
@@ -12,7 +12,6 @@ describe("Tokensoft Token Minter role permissions", () => {
     provider = await ProviderRegistry.createProvider()
     await createCheckAndDeploy(`${Accounts.alice}.ft-trait`, 'ft-trait', provider)
     await createCheckAndDeploy(`${Accounts.alice}.restricted-token-trait`, 'restricted-token-trait', provider)
-    await createCheckAndDeploy(`${Accounts.alice}.metadata-uri-token-trait`, 'metadata-uri-token-trait', provider)
     tokensoftTokenClient = await createCheckAndDeploy(`${Accounts.alice}.tokensoft-token`, "tokensoft-token", provider)
     await TokenHelper.Meta.initialize(
       tokensoftTokenClient,

--- a/test/roles/owner.ts
+++ b/test/roles/owner.ts
@@ -12,7 +12,6 @@ describe("Tokensoft Token Owner role permissions", () => {
     provider = await ProviderRegistry.createProvider()
     await createCheckAndDeploy(`${Accounts.alice}.ft-trait`, 'ft-trait', provider)
     await createCheckAndDeploy(`${Accounts.alice}.restricted-token-trait`, 'restricted-token-trait', provider)
-    await createCheckAndDeploy(`${Accounts.alice}.metadata-uri-token-trait`, 'metadata-uri-token-trait', provider)
     tokensoftTokenClient = await createCheckAndDeploy(`${Accounts.alice}.tokensoft-token`, "tokensoft-token", provider)
     await TokenHelper.Meta.initialize(
       tokensoftTokenClient,

--- a/test/roles/revoker.ts
+++ b/test/roles/revoker.ts
@@ -12,7 +12,6 @@ describe("Tokensoft Token Revoker role permissions", () => {
     provider = await ProviderRegistry.createProvider()
     await createCheckAndDeploy(`${Accounts.alice}.ft-trait`, 'ft-trait', provider)
     await createCheckAndDeploy(`${Accounts.alice}.restricted-token-trait`, 'restricted-token-trait', provider)
-    await createCheckAndDeploy(`${Accounts.alice}.metadata-uri-token-trait`, 'metadata-uri-token-trait', provider)
     tokensoftTokenClient = await createCheckAndDeploy(`${Accounts.alice}.tokensoft-token`, "tokensoft-token", provider)
     await TokenHelper.Meta.initialize(
       tokensoftTokenClient,

--- a/test/tokensoft-token-meta.ts
+++ b/test/tokensoft-token-meta.ts
@@ -12,7 +12,6 @@ describe("Tokensoft Token contract test suite", () => {
     provider = await ProviderRegistry.createProvider()
     await createCheckAndDeploy(`${Accounts.alice}.ft-trait`, 'ft-trait', provider)
     await createCheckAndDeploy(`${Accounts.alice}.restricted-token-trait`, 'restricted-token-trait', provider)
-    await createCheckAndDeploy(`${Accounts.alice}.metadata-uri-token-trait`, 'metadata-uri-token-trait', provider)
     tokensoftTokenClient = await createCheckAndDeploy(`${Accounts.alice}.tokensoft-token`, "tokensoft-token", provider)    
   })
 
@@ -73,7 +72,7 @@ describe("Tokensoft Token contract test suite", () => {
   it("should have a blank token URI by default", async () => {
     // assert.equal(await TokenHelper.Meta.tokenUri(tokensoftTokenClient), "")
     // Hack as unwrap library is not working correctly
-    assert.equal((await TokenHelper.Meta.tokenUri(tokensoftTokenClient)), "(ok u\"\")")
+    assert.equal((await TokenHelper.Meta.tokenUri(tokensoftTokenClient)), "(ok (some u\"\"))")
   })
 
   it("should have set bob as owner", async () => {    


### PR DESCRIPTION
After some recent discussion, I made some changes to your contracts to be in line with the updated comments from the SIP.

Two main changes:

- All the read-only functions are prefixed with `get-`
- The method `get-token-uri` has been added to the official trait, so I've removed your metadata trait and added it to `ft-trait`. The change to your implementation is that the response is `(optional (string-utf8 256))`. I made it an `optional` to be more in line with the ERC20 spec, where this method is considered optional - but this way we don't need to have two different traits.

Feel free to push back on these changes in the SIP! Especially the shortening to `256` from `1028`. With Clarity, you pay the full gas cost based on the max-length, so I thought it might be better to keep the trait shorter. I could be convinced otherwise.

I hope you don't mind me taking the liberty of updating your code - you obviously can totally reject these changes.

This repo is awesome! It's probably the most robust (and best tested) third-party contract in the Stacks ecosystem at this point.